### PR TITLE
[sc-15461] Revert compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 indent() {
   sed -u 's/^/       /'
@@ -13,8 +13,6 @@ TESSERACT_OCR_TGZ=tesseract-ocr-$TESSERACT_OCR_VERSION.tar.gz
 TESSERACT_OCR_DIR=$APP_DIR/vendor/tesseract-ocr
 ENVSCRIPT=$APP_DIR/.profile.d/tesseract-ocr.sh
 
-TESSERACT_OCR_LANGUAGES=eng
-
 echo "-----> Unpacking Tesseract-OCR binaries"
 mkdir -p $TESSERACT_OCR_DIR
 tar -zxvf $TESSERACT_OCR_TGZ -C $TESSERACT_OCR_DIR | indent
@@ -24,7 +22,3 @@ echo "-----> Building runtime environment for Tesseract-OCR"
 echo "export PATH=\"$TESSERACT_OCR_DIR/bin:\$PATH\"" > $ENVSCRIPT
 echo "export LD_LIBRARY_PATH=\"$TESSERACT_OCR_DIR/lib:\$LD_LIBRARY_PATH\"" >> $ENVSCRIPT
 echo "export TESSDATA_PREFIX=\"$TESSERACT_OCR_DIR/share/tessdata\"" >> $ENVSCRIPT
-
-echo "-----> Downloading custom language files"
-cd $APP_DIR
-MODEL_DIR="$TESSDATA_PREFIX" bundle exec rake ml_model:download_tesseract_model | indent


### PR DESCRIPTION
There is a native feature heroku provides called Release Phase which is designed to do exactly what we are trying to do here. So moving the logic to download a custom model there and cleaning this back to the original working version. Also remove a dead variable and switch the shebang to be the preferred version.